### PR TITLE
Updating MySql driver to latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>6.0.6</version>
+            <version>8.0.11</version>
         </dependency>
 
         <!-- Jackson -->


### PR DESCRIPTION
query_cache_size was removed in MySQL 8. Because of which if MySQL latest version is used, code wont run. 
Updating driver to latest version.